### PR TITLE
feat: battery display + GPS-only tracking mode replace #59

### DIFF
--- a/custom_components/oppo_cloud_tracker/api.py
+++ b/custom_components/oppo_cloud_tracker/api.py
@@ -621,8 +621,14 @@ observer.observe(document, { childList: true, subtree: true, characterData: true
             )
             for item in device_items:
                 driver.execute_script("arguments[0].click();", item)
-                time.sleep(1.5)
-        except Exception as exception:
+                with contextlib.suppress(TimeoutException):
+                    WebDriverWait(driver, 8).until(
+                        expected_conditions.presence_of_element_located(
+                            (By.CSS_SELECTOR, ".battery-wrapper")
+                        )
+                    )
+                time.sleep(1)
+        except WebDriverException as exception:
             LOGGER.warning("Failed to click device item for details: %s", exception)
 
         # Now read the fresh data from $findVm + battery from DOM
@@ -631,22 +637,26 @@ observer.observe(document, { childList: true, subtree: true, characterData: true
             if (!window.$findVm || !window.$findVm.deviceList) return null;
             var devices = JSON.parse(JSON.stringify(window.$findVm.deviceList));
 
-            var globalBattery = null;
-            var batteryEl = document.querySelector('.info-battery .count');
-            if (batteryEl) {
-                globalBattery = (batteryEl.innerText || batteryEl.textContent).replace('%', '').trim();
+            function _b(el) {
+                return (el.innerText || el.textContent)
+                    .replace('%', '').trim();
             }
 
+            var globalBatt = null;
+            var battEl = document.querySelector('.battery-wrapper');
+            if (battEl) { globalBatt = _b(battEl); }
+
+            var lis = document.querySelectorAll(
+                "#device-list .device-list ul > li");
             for (var i = 0; i < devices.length; i++) {
-                var localBatteryEl = null;
-                var liElems = document.querySelectorAll("#device-list .device-list ul > li");
-                if (liElems && liElems.length > i) {
-                    localBatteryEl = liElems[i].querySelector('.info-battery .count');
+                var local = null;
+                if (lis && lis.length > i) {
+                    local = lis[i].querySelector('.battery-wrapper');
                 }
-                if (localBatteryEl) {
-                    devices[i]._domBattery = (localBatteryEl.innerText || localBatteryEl.textContent).replace('%', '').trim();
-                } else if (globalBattery) {
-                    devices[i]._domBattery = globalBattery;
+                if (local) {
+                    devices[i]._domBattery = _b(local);
+                } else if (globalBatt) {
+                    devices[i]._domBattery = globalBatt;
                 }
             }
             return {
@@ -664,6 +674,7 @@ observer.observe(document, { childList: true, subtree: true, characterData: true
             device_data["deviceList"], device_data.get("points", [])
         )
 
+        LOGGER.info("Found %d devices in OPPO Cloud", len(devices))
         return devices
 
     def _parse_device_data(
@@ -727,14 +738,16 @@ observer.observe(document, { childList: true, subtree: true, characterData: true
                         exception,
                     )
 
-            battery_level_raw = device.get("_domBattery") or device.get("batteryLevel") or device.get("batteryPercent")
+            battery_level_raw = (
+                device.get("_domBattery")
+                or device.get("batteryLevel")
+                or device.get("batteryPercent")
+            )
 
             battery_level = None
             if battery_level_raw is not None:
-                try:
+                with contextlib.suppress(ValueError, TypeError):
                     battery_level = int(str(battery_level_raw).replace("%", "").strip())
-                except (ValueError, TypeError):
-                    pass
 
             result.append(
                 OppoCloudDevice(

--- a/custom_components/oppo_cloud_tracker/api.py
+++ b/custom_components/oppo_cloud_tracker/api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import re
+import time
 
 from selenium import webdriver
 from selenium.common.exceptions import (
@@ -611,38 +612,46 @@ observer.observe(document, { childList: true, subtree: true, characterData: true
         except TimeoutException:
             LOGGER.warning("Some devices are still updating, continuing anyway")
 
-        # Step 3: Wait for device item to have location info
+        # Step 3: Canvas rendering of battery requires clicking each device item
         try:
-            wait.until(
-                lambda d: (
-                    all(
-                        item.find_elements(By.CSS_SELECTOR, ".device-poi")
-                        or item.find_elements(
-                            By.CSS_SELECTOR,
-                            ".device-status-wrap:not(.positioning)",
-                        )
-                        for item in d.find_elements(
-                            By.CSS_SELECTOR,
-                            "#device-list .device-list ul > li",
-                        )
-                    )
-                    if d.find_elements(
-                        By.CSS_SELECTOR, "#device-list .device-list ul > li"
-                    )
-                    else True
+            device_items = wait.until(
+                expected_conditions.presence_of_all_elements_located(
+                    (By.CSS_SELECTOR, "#device-list .device-list ul > li")
                 )
             )
-        except TimeoutException:
-            LOGGER.warning("Not all device items settled, continuing anyway")
+            for item in device_items:
+                driver.execute_script("arguments[0].click();", item)
+                time.sleep(1.5)
+        except Exception as exception:
+            LOGGER.warning("Failed to click device item for details: %s", exception)
 
-        # Now read the fresh data from $findVm
+        # Now read the fresh data from $findVm + battery from DOM
         device_data = driver.execute_script(
             """
-            if (!window.$findVm || !window.$findVm.deviceList || !window.$findVm.points)
-                return null;
+            if (!window.$findVm || !window.$findVm.deviceList) return null;
+            var devices = JSON.parse(JSON.stringify(window.$findVm.deviceList));
+
+            var globalBattery = null;
+            var batteryEl = document.querySelector('.info-battery .count');
+            if (batteryEl) {
+                globalBattery = (batteryEl.innerText || batteryEl.textContent).replace('%', '').trim();
+            }
+
+            for (var i = 0; i < devices.length; i++) {
+                var localBatteryEl = null;
+                var liElems = document.querySelectorAll("#device-list .device-list ul > li");
+                if (liElems && liElems.length > i) {
+                    localBatteryEl = liElems[i].querySelector('.info-battery .count');
+                }
+                if (localBatteryEl) {
+                    devices[i]._domBattery = (localBatteryEl.innerText || localBatteryEl.textContent).replace('%', '').trim();
+                } else if (globalBattery) {
+                    devices[i]._domBattery = globalBattery;
+                }
+            }
             return {
-                deviceList: window.$findVm.deviceList,
-                points: window.$findVm.points
+                deviceList: devices,
+                points: window.$findVm.points || []
             };
             """
         )
@@ -655,7 +664,6 @@ observer.observe(document, { childList: true, subtree: true, characterData: true
             device_data["deviceList"], device_data.get("points", [])
         )
 
-        LOGGER.info("Found %d devices in OPPO Cloud", len(devices))
         return devices
 
     def _parse_device_data(
@@ -719,6 +727,15 @@ observer.observe(document, { childList: true, subtree: true, characterData: true
                         exception,
                     )
 
+            battery_level_raw = device.get("_domBattery") or device.get("batteryLevel") or device.get("batteryPercent")
+
+            battery_level = None
+            if battery_level_raw is not None:
+                try:
+                    battery_level = int(str(battery_level_raw).replace("%", "").strip())
+                except (ValueError, TypeError):
+                    pass
+
             result.append(
                 OppoCloudDevice(
                     device_model=device_model,
@@ -727,6 +744,7 @@ observer.observe(document, { childList: true, subtree: true, characterData: true
                     longitude=longitude,
                     last_seen=last_seen,
                     is_online=is_online,
+                    battery_level=battery_level,
                 )
             )
 

--- a/custom_components/oppo_cloud_tracker/data.py
+++ b/custom_components/oppo_cloud_tracker/data.py
@@ -30,8 +30,9 @@ class OppoCloudDevice:
     """Data for the OPPO Cloud devices."""
 
     device_model: str
-    location_name: str
+    location_name: str | None
     latitude: float | None
     longitude: float | None
     last_seen: str | None
     is_online: bool
+    battery_level: int | None = None

--- a/custom_components/oppo_cloud_tracker/device_tracker.py
+++ b/custom_components/oppo_cloud_tracker/device_tracker.py
@@ -27,10 +27,16 @@ async def async_setup_entry(
     """Set up the device tracker platform."""
     coordinator = entry.runtime_data.coordinator
 
+    # Wait for initial data to be loaded
     if not coordinator.data:
-        LOGGER.warning("No device data available yet, will add entities when data becomes available")
+        LOGGER.warning(
+            "No device data available yet, will add entities when data "
+            "becomes available"
+        )
         return
 
+    # Create device tracker entities for each device found
+    # coordinator.data is now list[OppoCloudDevice] directly
     devices = coordinator.data
     entities = [
         OppoCloudDeviceTracker(
@@ -60,6 +66,7 @@ class OppoCloudDeviceTracker(OppoCloudEntity, TrackerEntity):
         super().__init__(coordinator)
         self._device_index = device_index
         self._device = device
+        # Generate a unique device ID based on device model and index
         device_id = f"{device.device_model}_{device_index}"
         self._device_id = device_id
         self._attr_name = device.device_model
@@ -73,7 +80,7 @@ class OppoCloudDeviceTracker(OppoCloudEntity, TrackerEntity):
     @property
     def location_name(self) -> str | None:
         """Return the location name where the device was last seen."""
-        # 强制返回 None。这是启动 HA 纯 GPS 经纬度判定的核心所在！
+        # 强制返回 None。这是启动 HA 纯 GPS 经纬度判定的核心所在!
         return None
 
     @property
@@ -108,13 +115,15 @@ class OppoCloudDeviceTracker(OppoCloudEntity, TrackerEntity):
         if self.coordinator.data and self._device_index < len(self.coordinator.data):
             device = self.coordinator.data[self._device_index]
 
+            # Add device-specific attributes from OppoCloudDevice
+            # Dont add last_seen attribute because is updates frequently
             attributes["device_model"] = device.device_model
             attributes["is_online"] = str(device.is_online)
-            
+
             # 将提取出来的中文文本作为参考地址存入属性
             if device.location_name:
                 attributes["oppo_address"] = device.location_name
-                
+
             # 将获取到的电量存入属性
             if device.battery_level is not None:
                 attributes["battery_level"] = f"{device.battery_level}%"

--- a/custom_components/oppo_cloud_tracker/device_tracker.py
+++ b/custom_components/oppo_cloud_tracker/device_tracker.py
@@ -27,16 +27,10 @@ async def async_setup_entry(
     """Set up the device tracker platform."""
     coordinator = entry.runtime_data.coordinator
 
-    # Wait for initial data to be loaded
     if not coordinator.data:
-        LOGGER.warning(
-            "No device data available yet, will add entities when data "
-            "becomes available"
-        )
+        LOGGER.warning("No device data available yet, will add entities when data becomes available")
         return
 
-    # Create device tracker entities for each device found
-    # coordinator.data is now list[OppoCloudDevice] directly
     devices = coordinator.data
     entities = [
         OppoCloudDeviceTracker(
@@ -66,7 +60,6 @@ class OppoCloudDeviceTracker(OppoCloudEntity, TrackerEntity):
         super().__init__(coordinator)
         self._device_index = device_index
         self._device = device
-        # Generate a unique device ID based on device model and index
         device_id = f"{device.device_model}_{device_index}"
         self._device_id = device_id
         self._attr_name = device.device_model
@@ -75,15 +68,12 @@ class OppoCloudDeviceTracker(OppoCloudEntity, TrackerEntity):
     @property
     def source_type(self) -> SourceType:
         """Return the source type of the device."""
-        # Since we only have location names, not GPS coordinates
         return SourceType.GPS
 
     @property
     def location_name(self) -> str | None:
         """Return the location name where the device was last seen."""
-        if self.coordinator.data and self._device_index < len(self.coordinator.data):
-            device = self.coordinator.data[self._device_index]
-            return device.location_name
+        # 强制返回 None。这是启动 HA 纯 GPS 经纬度判定的核心所在！
         return None
 
     @property
@@ -118,9 +108,15 @@ class OppoCloudDeviceTracker(OppoCloudEntity, TrackerEntity):
         if self.coordinator.data and self._device_index < len(self.coordinator.data):
             device = self.coordinator.data[self._device_index]
 
-            # Add device-specific attributes from OppoCloudDevice
-            # Dont add last_seen attribute because is updates frequently
             attributes["device_model"] = device.device_model
             attributes["is_online"] = str(device.is_online)
+            
+            # 将提取出来的中文文本作为参考地址存入属性
+            if device.location_name:
+                attributes["oppo_address"] = device.location_name
+                
+            # 将获取到的电量存入属性
+            if device.battery_level is not None:
+                attributes["battery_level"] = f"{device.battery_level}%"
 
         return attributes


### PR DESCRIPTION
Supersedes #59. Rebased onto main with conflict resolution.

Original work by **@autunn**:
- Add `battery_level` to OppoCloudDevice dataclass
- Scrape battery percentage from DOM via per-device click
- `location_name` returns None for pure GPS-based home detection
- Add `oppo_address` and `battery_level` to entity extra_state_attributes

Fixups:
- Correct battery CSS selector (`.info-battery .count` → `.battery-wrapper`)
- WebDriverWait for battery element instead of blind sleep
- Ruff compliance pass